### PR TITLE
App Install Location

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.thefonz.ed_tool" >
+    package="com.thefonz.ed_tool"
+    android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 


### PR DESCRIPTION
The internal memory of my device is quite small, this PR should allow users to easily move the app to the microSD.

"To allow the system to install your application on the external storage, modify your manifest file to include the android:installLocation attribute in the element, with a value of either "preferExternal" or "auto"." (source: https://developer.android.com/guide/topics/data/install-location.html)

Thank you very much for your awesome app :+1: 
